### PR TITLE
feat(init): public package API — 42 exported symbols

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,136 @@
+"""
+Optimization Module
+===================
+
+Comprehensive optimization algorithms for machine learning and deep learning.
+
+Modules:
+--------
+- optimizers: Gradient-based optimizers (SGD, Adam, RMSProp, etc.)
+- learning_rate: Learning rate schedules and decay strategies
+- line_search: Line search methods (backtracking, Wolfe conditions)
+- second_order: Second-order methods (Newton, BFGS, L-BFGS)
+- constrained: Constrained optimization (Lagrange, KKT, projected gradient)
+- global_opt: Global optimization (simulated annealing, genetic algorithms)
+"""
+
+__version__ = "1.0.0"
+# Public API count: 42 symbols (see __all__ below)
+
+from .optimizers import (
+    Optimizer,
+    SGD,
+    Momentum,
+    NesterovMomentum,
+    Adagrad,
+    RMSprop,
+    Adam,
+    AdaMax,
+    NAdam,
+    AMSGrad,
+    clip_gradients,
+    clip_gradients_value,
+)
+
+from .learning_rate import (
+    LRSchedule,
+    ConstantLR,
+    StepDecayLR,
+    ExponentialDecayLR,
+    CosineAnnealingLR,
+    WarmRestartLR,
+    PolynomialDecayLR,
+    OneCycleLR,
+    ReduceLROnPlateau,
+)
+
+from .line_search import (
+    backtracking_line_search,
+    wolfe_line_search,
+    wolfe_conditions,
+    armijo_condition,
+    exact_line_search_quadratic,
+    golden_section_search,
+)
+
+from .second_order import (
+    newton_step,
+    NewtonMethod,
+    BFGS,
+    LBFGS,
+    ConjugateGradient,
+)
+
+from .constrained import (
+    lagrange_multiplier,
+    kkt_conditions,
+    projected_gradient_descent,
+    barrier_method,
+    box_projection,
+    simplex_projection,
+)
+
+from .global_opt import (
+    simulated_annealing,
+    genetic_algorithm,
+    particle_swarm_optimization,
+    differential_evolution,
+)
+
+__all__ = [
+    # Base classes (for subclassing / isinstance checks)
+    'Optimizer',
+    'LRSchedule',
+
+    # Optimizers
+    'SGD',
+    'Momentum',
+    'NesterovMomentum',
+    'Adagrad',
+    'RMSprop',
+    'Adam',
+    'AdaMax',
+    'NAdam',
+    'AMSGrad',
+    'clip_gradients',
+    'clip_gradients_value',
+
+    # Learning Rate Schedules
+    'ConstantLR',
+    'StepDecayLR',
+    'ExponentialDecayLR',
+    'CosineAnnealingLR',
+    'WarmRestartLR',
+    'PolynomialDecayLR',
+    'OneCycleLR',
+    'ReduceLROnPlateau',
+
+    # Line Search
+    'backtracking_line_search',
+    'wolfe_line_search',
+    'wolfe_conditions',
+    'armijo_condition',
+    'exact_line_search_quadratic',
+    'golden_section_search',
+
+    # Second-Order Methods
+    'newton_step',
+    'NewtonMethod',
+    'BFGS',
+    'LBFGS',
+    'ConjugateGradient',
+
+    # Constrained Optimization
+    'lagrange_multiplier',
+    'kkt_conditions',
+    'projected_gradient_descent',
+    'barrier_method',
+    'box_projection',
+    'simplex_projection',
+
+    # Global Optimization
+    'simulated_annealing',
+    'genetic_algorithm',
+    'particle_swarm_optimization',
+    'differential_evolution',
+]


### PR DESCRIPTION
## Summary
- Defines `__init__.py` as the single public surface of the library
- Exports all 42 symbols across 6 sub-modules into the top-level namespace
- Makes `Optimizer` and `LRSchedule` base classes importable without knowing internal module paths
- Adds `newton_step` to public API so callers can compute Newton directions standalone

## Changes
- `from .optimizers import Optimizer, SGD, Momentum, ...`
- `from .learning_rate import LRSchedule, ConstantLR, ...`
- `from .line_search import backtracking_line_search, ...`
- `from .second_order import newton_step, NewtonMethod, ...`
- `from .constrained import lagrange_multiplier, ...`
- `from .global_opt import simulated_annealing, ...`
- Complete `__all__` list with 42 symbols

## References
Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimization package now available with version 1.0.0, providing a curated public API including gradient-based optimizers (SGD, Adam, RMSprop, etc.), learning-rate schedules, line-search routines, second-order methods, constrained optimization helpers, and global optimization algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->