### PR TITLE
feat(init): update __init__.py to export all 119 v2.0.0 public symbols

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,344 @@
+"""
+Optimization Module
+===================
+
+Comprehensive pure-Python optimization library (stdlib only).
+
+Modules
+-------
+- optimizers       : Gradient-based first-order optimizers
+- learning_rate    : Learning rate schedules and decay strategies
+- line_search      : Line search methods (Armijo, Wolfe, Brent, strong Wolfe)
+- second_order     : Second-order methods (Newton, BFGS, L-BFGS, SR1, LM, trust-region)
+- constrained      : Constrained optimization (projections, penalty, AL, Frank-Wolfe, ADMM)
+- global_opt       : Global/metaheuristic optimization (SA, GA, DE, PSO, Nelder-Mead, CMA-ES)
+- stochastic       : Variance-reduced stochastic methods (SVRG, SAGA, SAG, Polyak averaging)
+- proximal         : Proximal operators and algorithms (ISTA, FISTA, Douglas-Rachford)
+- multi_objective  : Multi-objective optimization (NSGA-II, Pareto front, weighted sum)
+- utilities        : Gradient checking, test functions, benchmarking, callbacks, checkpointing
+"""
+
+__version__ = '2.0.0'
+
+# ---------------------------------------------------------------------------
+# Learning rate schedules
+# ---------------------------------------------------------------------------
+from .learning_rate import (
+    LRSchedule,
+    ConstantLR,
+    StepDecayLR,
+    ExponentialDecayLR,
+    CosineAnnealingLR,
+    WarmRestartLR,
+    PolynomialDecayLR,
+    OneCycleLR,
+    ReduceLROnPlateau,
+    LinearWarmupLR,
+    CyclicLR,
+    NoamLR,
+    ComposedLR,
+)
+
+# ---------------------------------------------------------------------------
+# Gradient-based optimizers
+# ---------------------------------------------------------------------------
+from .optimizers import (
+    clip_gradients,
+    clip_gradients_value,
+    Optimizer,
+    SGD,
+    Momentum,
+    NesterovMomentum,
+    Adagrad,
+    RMSprop,
+    Adam,
+    AdaMax,
+    NAdam,
+    AMSGrad,
+    AdamW,
+    RAdam,
+    Adadelta,
+    Lookahead,
+    Lion,
+)
+
+# ---------------------------------------------------------------------------
+# Line search
+# ---------------------------------------------------------------------------
+from .line_search import (
+    backtracking_line_search,
+    wolfe_line_search,
+    brent_minimize,
+    cubic_interpolation_line_search,
+    strong_wolfe_line_search,
+)
+
+# ---------------------------------------------------------------------------
+# Second-order methods
+# ---------------------------------------------------------------------------
+from .second_order import (
+    newton_raphson,
+    bfgs,
+    lbfgs,
+    sr1,
+    gauss_newton,
+    levenberg_marquardt,
+    trust_region,
+    newton_cg,
+)
+
+# ---------------------------------------------------------------------------
+# Constrained optimization
+# ---------------------------------------------------------------------------
+from .constrained import (
+    project_box,
+    project_simplex,
+    project_l2_ball,
+    project_l1_ball,
+    project_linf_ball,
+    projected_gradient,
+    penalty_method,
+    augmented_lagrangian,
+    frank_wolfe,
+    admm,
+    barrier_method,
+)
+
+# ---------------------------------------------------------------------------
+# Global / metaheuristic optimization
+# ---------------------------------------------------------------------------
+from .global_opt import (
+    simulated_annealing,
+    genetic_algorithm,
+    differential_evolution,
+    particle_swarm,
+    nelder_mead,
+    cma_es,
+    basin_hopping,
+    random_search,
+    latin_hypercube_search,
+)
+
+# ---------------------------------------------------------------------------
+# Stochastic variance-reduced methods
+# ---------------------------------------------------------------------------
+from .stochastic import (
+    svrg,
+    SAGAOptimizer,
+    SAGOptimizer,
+    iterate_averaging,
+    robbins_monro,
+)
+
+# ---------------------------------------------------------------------------
+# Proximal operators and algorithms
+# ---------------------------------------------------------------------------
+from .proximal import (
+    prox_l1,
+    prox_l2_sq,
+    prox_linf,
+    prox_non_negative,
+    prox_box,
+    prox_elastic_net,
+    ista,
+    fista,
+    proximal_gradient,
+    douglas_rachford,
+)
+
+# ---------------------------------------------------------------------------
+# Multi-objective optimization
+# ---------------------------------------------------------------------------
+from .multi_objective import (
+    dominates,
+    pareto_front,
+    crowding_distance,
+    fast_non_dominated_sort,
+    nsga2,
+    weighted_sum,
+    generate_weight_vectors,
+)
+
+# ---------------------------------------------------------------------------
+# Utilities: gradient checking, test functions, benchmarking, callbacks
+# ---------------------------------------------------------------------------
+from .utilities import (
+    check_gradient,
+    check_jacobian,
+    numerical_gradient,
+    numerical_hessian,
+    sphere,
+    sphere_grad,
+    rosenbrock,
+    rosenbrock_grad,
+    rastrigin,
+    rastrigin_grad,
+    ackley,
+    ackley_grad,
+    himmelblau,
+    himmelblau_grad,
+    beale,
+    beale_grad,
+    booth,
+    booth_grad,
+    matyas,
+    three_hump_camel,
+    styblinski_tang,
+    BenchmarkResult,
+    benchmark_optimizer,
+    compare_optimizers,
+    Callback,
+    CallbackList,
+    EarlyStopping,
+    GradientMonitor,
+    LossLogger,
+    DivergenceDetector,
+    save_state,
+    load_state,
+    check_finite,
+    safe_step,
+)
+
+__all__ = [
+    # ---- version ----
+    '__version__',
+
+    # ---- LR schedules ----
+    'LRSchedule',
+    'ConstantLR',
+    'StepDecayLR',
+    'ExponentialDecayLR',
+    'CosineAnnealingLR',
+    'WarmRestartLR',
+    'PolynomialDecayLR',
+    'OneCycleLR',
+    'ReduceLROnPlateau',
+    'LinearWarmupLR',
+    'CyclicLR',
+    'NoamLR',
+    'ComposedLR',
+
+    # ---- optimizers ----
+    'clip_gradients',
+    'clip_gradients_value',
+    'Optimizer',
+    'SGD',
+    'Momentum',
+    'NesterovMomentum',
+    'Adagrad',
+    'RMSprop',
+    'Adam',
+    'AdaMax',
+    'NAdam',
+    'AMSGrad',
+    'AdamW',
+    'RAdam',
+    'Adadelta',
+    'Lookahead',
+    'Lion',
+
+    # ---- line search ----
+    'backtracking_line_search',
+    'wolfe_line_search',
+    'brent_minimize',
+    'cubic_interpolation_line_search',
+    'strong_wolfe_line_search',
+
+    # ---- second-order ----
+    'newton_raphson',
+    'bfgs',
+    'lbfgs',
+    'sr1',
+    'gauss_newton',
+    'levenberg_marquardt',
+    'trust_region',
+    'newton_cg',
+
+    # ---- constrained ----
+    'project_box',
+    'project_simplex',
+    'project_l2_ball',
+    'project_l1_ball',
+    'project_linf_ball',
+    'projected_gradient',
+    'penalty_method',
+    'augmented_lagrangian',
+    'frank_wolfe',
+    'admm',
+    'barrier_method',
+
+    # ---- global / metaheuristic ----
+    'simulated_annealing',
+    'genetic_algorithm',
+    'differential_evolution',
+    'particle_swarm',
+    'nelder_mead',
+    'cma_es',
+    'basin_hopping',
+    'random_search',
+    'latin_hypercube_search',
+
+    # ---- stochastic ----
+    'svrg',
+    'SAGAOptimizer',
+    'SAGOptimizer',
+    'iterate_averaging',
+    'robbins_monro',
+
+    # ---- proximal ----
+    'prox_l1',
+    'prox_l2_sq',
+    'prox_linf',
+    'prox_non_negative',
+    'prox_box',
+    'prox_elastic_net',
+    'ista',
+    'fista',
+    'proximal_gradient',
+    'douglas_rachford',
+
+    # ---- multi-objective ----
+    'dominates',
+    'pareto_front',
+    'crowding_distance',
+    'fast_non_dominated_sort',
+    'nsga2',
+    'weighted_sum',
+    'generate_weight_vectors',
+
+    # ---- utilities ----
+    'check_gradient',
+    'check_jacobian',
+    'numerical_gradient',
+    'numerical_hessian',
+    'sphere',
+    'sphere_grad',
+    'rosenbrock',
+    'rosenbrock_grad',
+    'rastrigin',
+    'rastrigin_grad',
+    'ackley',
+    'ackley_grad',
+    'himmelblau',
+    'himmelblau_grad',
+    'beale',
+    'beale_grad',
+    'booth',
+    'booth_grad',
+    'matyas',
+    'three_hump_camel',
+    'styblinski_tang',
+    'BenchmarkResult',
+    'benchmark_optimizer',
+    'compare_optimizers',
+    'Callback',
+    'CallbackList',
+    'EarlyStopping',
+    'GradientMonitor',
+    'LossLogger',
+    'DivergenceDetector',
+    'save_state',
+    'load_state',
+    'check_finite',
+    'safe_step',
+]


### PR DESCRIPTION
## Overview

Updates `__init__.py` to expose the complete v2.0.0 public API: 119 symbols from 10 modules, setting version to `'2.0.0'`.

## Changes

### Version bump
```python
__version__ = '2.0.0'
```

### New module imports (5 new modules)
All new modules introduced in v2 are now re-exported at the top level:
- `from .stochastic import svrg, SAGAOptimizer, SAGOptimizer, iterate_averaging, robbins_monro`
- `from .proximal import prox_l1, prox_l2_sq, prox_linf, prox_non_negative, prox_box, prox_elastic_net, ista, fista, proximal_gradient, douglas_rachford`
- `from .multi_objective import dominates, pareto_front, crowding_distance, fast_non_dominated_sort, nsga2, weighted_sum, generate_weight_vectors`
- `from .constrained import project_box, project_simplex, project_l2_ball, project_l1_ball, project_linf_ball, projected_gradient, penalty_method, augmented_lagrangian, frank_wolfe, admm, barrier_method`
- `from .global_opt import simulated_annealing, genetic_algorithm, differential_evolution, particle_swarm, nelder_mead, cma_es, basin_hopping, random_search, latin_hypercube_search`

### Extended existing module exports
New symbols added from existing modules:
- `optimizers`: + `AdamW, RAdam, Adadelta, Lookahead, Lion`
- `learning_rate`: + `LinearWarmupLR, CyclicLR, NoamLR, ComposedLR`
- `line_search`: + `cubic_interpolation_line_search, strong_wolfe_line_search`
- `second_order`: + `sr1, gauss_newton, levenberg_marquardt, trust_region, newton_cg`
- `utilities`: + `check_jacobian, numerical_hessian, BenchmarkResult, benchmark_optimizer, compare_optimizers, Callback, CallbackList, EarlyStopping, GradientMonitor, LossLogger, DivergenceDetector, save_state, load_state, check_finite, safe_step`

### `__all__` list
Complete `__all__` of 119 symbols for clean `from optimization import *` support.

## Symbol Count

| Module | Symbols |
|---|---|
| optimizers | 17 (14 optimizers + base + 2 clipping) |
| learning_rate | 13 (LRSchedule ABC + 12 schedules) |
| line_search | 5 |
| second_order | 8 |
| constrained | 11 (5 projections + 6 algorithms) |
| global_opt | 9 |
| stochastic | 5 |
| proximal | 10 (6 prox ops + 4 algorithms) |
| multi_objective | 7 |
| utilities | 34 |
| **Total** | **119** |